### PR TITLE
fix: get-started/routing home link

### DIFF
--- a/01_get_started/02_routing/pages/more-fun/index.vue
+++ b/01_get_started/02_routing/pages/more-fun/index.vue
@@ -4,7 +4,7 @@
     <nav>
       <ul>
         <li>
-          <NuxtLink to="/home">Home page</NuxtLink>
+          <NuxtLink to="/">Home page</NuxtLink>
         </li>
         <li>
           <NuxtLink to="/fun">Fun page</NuxtLink>


### PR DESCRIPTION
Fix home link in the guides examples 01_get_started/02_routing/pages/more-fun/index.vue.